### PR TITLE
Improved compatibility for non-jQuery and non-Bootstrap projects

### DIFF
--- a/cookiebanner/templates/cookiebanner/bootstrap4.html
+++ b/cookiebanner/templates/cookiebanner/bootstrap4.html
@@ -63,7 +63,7 @@
     let cookiebannerCookie = keyValue ? decodeURIComponent(keyValue.slice(13)) : null;
     if (cookiebannerCookie) return;
 
-    document.querySelector('#cookiebannerModal').modal?.({
+    $?.('#cookiebannerModal').modal?.({
       backdrop: 'static',
       keyboard: false
     });


### PR DESCRIPTION
Hey,

I'm with https://github.com/geekzonehq and we forked this project a while back to make some improvements so it would be compatible with our own project, which doesn't use jQuery or Bootstrap.

The changes include removing all jQuery references outside of the `modal` function, and adding optional chaining to the `modal` function so the script still works even if Bootstrap isn't referenced.

It should work just the same with Bootstrap - I've tested it briefly - but feel free to test it yourself and let me know what you think.

Thanks!